### PR TITLE
資料詳細ページに「所蔵情報の新規作成」リンクを追加

### DIFF
--- a/app/views/manifestations/_show_detail_librarian.html.erb
+++ b/app/views/manifestations/_show_detail_librarian.html.erb
@@ -95,9 +95,7 @@
         </tr>
       </table>
     <% end %>
-      <%- if manifestation.items.on_shelf.exists? -%>
-        <%= render 'manifestations/show_holding', :manifestation => manifestation -%>
-      <%- end -%>
+      <%= render 'manifestations/show_holding', :manifestation => manifestation -%>
     </div>
     <%= render 'manifestations/tab_list', :manifestation => manifestation %>
   </div>

--- a/app/views/manifestations/_show_holding.html.erb
+++ b/app/views/manifestations/_show_holding.html.erb
@@ -57,4 +57,7 @@
     <% end %>
   <%- end -%>
 </table>
+<%- if can? :create, Item -%>
+<p><%= link_to t('page.new', :model => t('activerecord.models.item')), new_manifestation_item_path(manifestation) -%></p>
+<%- end -%>
 </div>


### PR DESCRIPTION
所蔵情報を追加できる権限を持つユーザーに対して、資料詳細ページから所蔵の追加ページに直接移動できるリンクを表示します。
これにより、資料詳細ページ→所蔵を編集→所蔵情報の新規作成 の順にリンクを辿る手間を省きます。

![資料詳細ページに追加されたリンク](https://f.cloud.github.com/assets/92577/1839934/2ce30464-7488-11e3-95b2-a392b776a14e.png)
